### PR TITLE
Removed empty depends line that causes package installation to fail o…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Maintainer: Joe Cheng <joe@rstudio.com>
 Description: Create zoomable heatmaps that are usable from the R console, in the
     RStudio viewer pane, in R Markdown documents, and in Shiny apps.
 License: GPL-3 | file LICENSE
-Depends:
 Imports:
     stats,
     leaflet,

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -45,6 +45,7 @@ d3heatmap <- function(x,
   cluster = !any(is.na(x)),
   theme = NULL,
   colors = "RdYlBu",
+  rev_colors = F,
   width = NULL, height = NULL,
   xaxis_height = 120,
   yaxis_width = 120,
@@ -104,6 +105,7 @@ d3heatmap <- function(x,
   domain <- seq.int(rng[1], rng[2], length.out = 100)
   
   colors <- leaflet::colorNumeric(colors, 1:100)(1:100)
+  if (rev_colors) colors <- rev(colors)
 
   matrix <- list(data = as.numeric(t(matrix)),
     dim = dim(matrix),


### PR DESCRIPTION
…n linux (similar to: https://github.com/hadley/devtools/issues/774)

Error before change:
Error in isNamespaceLoaded(pkg) : 
  attempt to use zero-length variable name