### PR TITLE
k_row now works even if dendextend is not on the search path

### DIFF
--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -286,6 +286,11 @@ d3heatmap <- function(x,
   ##=======================
 
   # color branches?
+  #----------------
+    # Due to the internal working of dendextend, in order to use it we first need
+      # to populate the dendextend::dendextend_options() space:
+  if(!missing(k_row) | !missing(k_col)) dendextend::assign_dendextend_options()
+  
   if(is.dendrogram(Rowv) & !missing(k_row)) {
     Rowv <- dendextend::color_branches(Rowv, k = k_row)
   }


### PR DESCRIPTION
dendextend 0.18.3 relies on a hidden environment created by dendextend::assign_dendextend_options(), which is not automatically created when calling dendextend::some_function.

This is an issue in dendextend 0.18.3 that was fixed in dendextend 1.0.0 (but is not yet on CRAN).

In order to keep backward compatibility, the added code resolves this issue.