### PR TITLE
Extra labels for Heatmap

### DIFF
--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -148,7 +148,7 @@ d3heatmap <- function(x,
   nc <- dim(x)[2]
   
   # if there are no labels, need to append them anyway for JS function
-  if (labels == NULL) labels <- matrix(NA, nr, nc)
+  if (labels == NULL) labels <- matrix("", nr, nc)
   #labels must be the same dimensions as the input data
   if (dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
   if (dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -150,8 +150,8 @@ d3heatmap <- function(x,
   # if there are no labels, need to append them anyway for JS function
   if (is.null(labels)) labels <- matrix("", nr, nc)
   #labels must be the same dimensions as the input data
-  if (dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
-  if (dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
+  if (!is.null(labels) && dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
+  if (!is.null(labels) && dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
   
   ### TODO: debating if to include this or not:
   #   if(nr <= 1 || nc <= 1)

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -153,7 +153,7 @@ d3heatmap <- function(x,
   #labels must be the same dimensions as the input data
   if (!is.null(labels)){
     if(dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
-    dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
+    if(dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
   }
 
   

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -148,7 +148,7 @@ d3heatmap <- function(x,
   nc <- dim(x)[2]
   
   # if there are no labels, need to append them anyway for JS function
-  if (labels == NULL) {labels <- matrix("", nr, nc)}
+  if (is.null(labels)) labels <- matrix("", nr, nc)
   #labels must be the same dimensions as the input data
   if (dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
   if (dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -91,7 +91,7 @@ NULL
 d3heatmap <- function(x,
   
   ## extra labels for final plot
-  labels,
+  labels = NULL,
   
   ## dendrogram control
   Rowv = TRUE,
@@ -147,11 +147,11 @@ d3heatmap <- function(x,
   nr <- dim(x)[1]
   nc <- dim(x)[2]
   
+  # if there are no labels, need to append them anyway for JS function
+  if (labels == NULL) labels <- matrix(NA, nr, nc)
   #labels must be the same dimensions as the input data
   if (dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
   if (dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
-  
-  
   
   ### TODO: debating if to include this or not:
   #   if(nr <= 1 || nc <= 1)
@@ -320,7 +320,7 @@ d3heatmap <- function(x,
               dim = dim(x),
               rows = rownames(x),
               cols = colnames(x),
-              labels = as.character(t(y))
+              labels = as.character(t(labels))
   )
   
     

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -149,9 +149,13 @@ d3heatmap <- function(x,
   
   # if there are no labels, need to append them anyway for JS function
   if (is.null(labels)) labels <- matrix("", nr, nc)
+  
   #labels must be the same dimensions as the input data
-  if (!is.null(labels) && dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
-  if (!is.null(labels) && dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
+  if (!is.null(labels)){
+    if(dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
+    dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
+  }
+
   
   ### TODO: debating if to include this or not:
   #   if(nr <= 1 || nc <= 1)

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -150,12 +150,9 @@ d3heatmap <- function(x,
   # if there are no labels, need to append them anyway for JS function
   if (is.null(labels)) labels <- matrix("", nr, nc)
   
-  #labels must be the same dimensions as the input data
-  if (!is.null(labels)){
-    if(dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
-    if(dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
-  }
-
+  #labels must be the same dimensions as the input data (should not be null anymore)
+  if(dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
+  if(dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
   
   ### TODO: debating if to include this or not:
   #   if(nr <= 1 || nc <= 1)

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -89,7 +89,10 @@ NULL
 #' 
 #' 
 d3heatmap <- function(x,
-
+  
+  ## extra labels for final plot
+  labels,
+  
   ## dendrogram control
   Rowv = TRUE,
   Colv = if (symm) "Rowv" else TRUE,
@@ -143,6 +146,13 @@ d3heatmap <- function(x,
   
   nr <- dim(x)[1]
   nc <- dim(x)[2]
+  
+  #labels must be the same dimensions as the input data
+  if (dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
+  if (dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")
+  
+  
+  
   ### TODO: debating if to include this or not:
   #   if(nr <= 1 || nc <= 1)
   #     stop("`x' must have at least 2 rows and 2 columns")
@@ -309,7 +319,8 @@ d3heatmap <- function(x,
   mtx <- list(data = as.character(t(cellnote)),
               dim = dim(x),
               rows = rownames(x),
-              cols = colnames(x)
+              cols = colnames(x),
+              labels = as.character(t(y))
   )
   
     

--- a/R/d3heatmap.R
+++ b/R/d3heatmap.R
@@ -148,7 +148,7 @@ d3heatmap <- function(x,
   nc <- dim(x)[2]
   
   # if there are no labels, need to append them anyway for JS function
-  if (labels == NULL) labels <- matrix("", nr, nc)
+  if (labels == NULL) {labels <- matrix("", nr, nc)}
   #labels must be the same dimensions as the input data
   if (dim(labels)[1] != nr) stop("labels must be the same dimensions as data: Issue Rows")
   if (dim(labels)[2] != nc) stop("labels must be the same dimensions as data: Issue Columns")

--- a/inst/htmlwidgets/d3heatmap.js
+++ b/inst/htmlwidgets/d3heatmap.js
@@ -48,7 +48,7 @@ HTMLWidgets.widget({
         var b = imgData[i*4+2];
         var a = imgData[i*4+3];
         merged.push({
-          label: x.matrix.data[i],
+          label: x.matrix.data[i] + " " + x.matrix.labels[i],
           color: "rgba(" + [r,g,b,a/255].join(",") + ")"
         })
       }


### PR DESCRIPTION
I work with field data where blocks effectively represent data, but in many cases the Row and Column isn't terribly helpful since these are little more than coordinates (1, 3). I hacked the functions to allow adding an extra label that is input as a matrix or data.frame or similar, of the same dimensions as the data. 

```r
## un-comment to install my version
#devtools::install_github("bhive01/d3heatmap")

require(d3heatmap)

#create fake data
df1 <- data.frame(matrix(runif(300), 30, 10))

#create fake, but unique labels
df2 <- NA
for (i in 1:300) {
	df2[i] <- paste0(sample(LETTERS, size=5), collapse="")
	}

df2 <- data.frame(matrix(df2, 30, 10))

#plot without dendrogram or scaling
d3hmplot <- function(data, labels = NULL) {
	d3heatmap(data, labels , Rowv = FALSE, Colv = FALSE, dendrogram = "none", scale="none", distfun = NULL)
}

#without extra labels
d3hmplot(data=df1)

#with extra labels
d3hmplot(data=df1, labels = df2)
```

I have not tested this with the dendrogram or scaling. It probably breaks when you do that, and labeling wouldn't make much sense then anyway. 