### PR TITLE
Make the css rules more specific to avoid name conflicts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+* Fix [rstudio/shinydashboard#75](https://github.com/rstudio/shinydashboard/issues/75): make the css rules in heatmap.css a bit more specific, so there's no name conflicts with other packages/code.
+
 d3heatmap 0.6.1.1 (2015-02-23)
 ----------------------------------------
 

--- a/inst/www/heatmap.css
+++ b/inst/www/heatmap.css
@@ -22,11 +22,13 @@
   border: 1px solid #CCC;
   overflow: hidden;
 }
-.inner {
+
+.d3-heatmap .inner {
   position: relative;
   top: -70px;
 }
-.info {
+
+.d3-heatmap .info {
   position: absolute;
   left: 20px;
   top: 90px;
@@ -36,21 +38,24 @@
   font-size: 40px;
   padding-top: 118px;
 }
-.colDend {
+
+.d3-heatmap .colDend {
   position: absolute;
   top: 0;
   left: 200px;
   width: 600px;
   height: 250px;
 }
-.rowDend {
+
+.d3-heatmap .rowDend {
   position: absolute;
   left: 0;
   top: 250px;
   height: 500px;
   width: 200px;
 }
-.colormap {
+
+.d3-heatmap .colormap {
   position: absolute;
   left: 200px;
   top: 250px;
@@ -58,9 +63,11 @@
   height: 500px;
   shape-rendering: crispEdges;
 }
+
 .highlighting text {
   fill: rgba(0, 0, 0, 0.25);
 }
+
 .highlighting text.active {
   fill: black;
 }


### PR DESCRIPTION
This fixes [rstudio/shinydashboard#75](https://github.com/rstudio/shinydashboard/issues/75) by making the css rules in heatmap.css a bit more specific, so there's no name conflicts with other packages/code.

**Reprex**
Uncomment the commented line and see that the text "Welcome back User!" (inside the `sidebarUserPanel()` function) disappears:

```r
library(shiny)
library(shinydashboard)

ui <- dashboardPage(
    dashboardHeader(),
    dashboardSidebar(sidebarUserPanel("Welcome back User!")),
    dashboardBody(
        # d3heatmap::d3heatmapOutput("map")
    )
)

server <- function(input, output, session) {}
shinyApp(ui, server)
```

@jcheng5, @wch, I changed all the rules for elements that were easily identifiable as children of `.d3-heatmap`, but it may be a good idea to change everything in the proper way...